### PR TITLE
Calling ObtainCert() should be no-op if certificate already obtained

### DIFF
--- a/config.go
+++ b/config.go
@@ -289,6 +289,10 @@ func (cfg *Config) ObtainCert(name string, interactive bool) error {
 		return nil
 	}
 
+	if cfg.storageHasCertResources(name) {
+		return nil
+	}
+
 	client, err := cfg.newACMEClient(interactive)
 	if err != nil {
 		return err


### PR DESCRIPTION
This does not affect RenewCert(), which should obviously happen if a
certificate already exists.

Fixes mholt/caddy#2400