### PR TITLE
Don't re-prompt for email if account already exists

### DIFF
--- a/config.go
+++ b/config.go
@@ -293,6 +293,9 @@ func (cfg *Config) Manage(domainNames []string) error {
 // it does not load them into memory. If interactive is true,
 // the user may be shown a prompt.
 func (cfg *Config) ObtainCert(name string, interactive bool) error {
+	if cfg.storageHasCertResources(name) {
+		return nil
+	}
 	skip, err := cfg.preObtainOrRenewChecks(name, interactive)
 	if err != nil {
 		return err
@@ -300,16 +303,10 @@ func (cfg *Config) ObtainCert(name string, interactive bool) error {
 	if skip {
 		return nil
 	}
-
-	if cfg.storageHasCertResources(name) {
-		return nil
-	}
-
 	client, err := cfg.newACMEClient(interactive)
 	if err != nil {
 		return err
 	}
-
 	return client.Obtain(name)
 }
 

--- a/user_test.go
+++ b/user_test.go
@@ -178,6 +178,7 @@ func TestGetEmailFromUserInput(t *testing.T) {
 func TestGetEmailFromRecent(t *testing.T) {
 	defer os.RemoveAll(testStorageDir)
 	testConfig.Email = ""
+	Email = ""
 	for i, eml := range []string{
 		"test4-1@foo.com",
 		"test4-2@foo.com",


### PR DESCRIPTION
Extracting CertMagic out of Caddy was a new and complicated surgery,
and although successful, it wasn't without its side-effects. One of
them was we slightly altered some of the subtle logic related to
getting an email address in order to know which account to use.

If an ACME account with an empty email already exists, and no Email is
available on the config, that account should be used without prompting
the user over and over. If no account exists and no email is available,
then yes a prompt is warranted. And of course if an email is set or an
account with a non-empty email exists, that should be used without
prompts (this was already the case).

This commit fixes to align with that expectation, so that accounts with
empty emails can be reused, if present.

Empty emails should only be used in dev or testing environments;
omitting them in production is bad practice.